### PR TITLE
Change linters to treat each application individually

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,27 @@ repos:
     hooks:
       - id: pylint
         name: Pylint - check for errors in Python code
+        files: ^(?!.*\/kbqa\/).*
         additional_dependencies:
           [rdflib==6.0.2, requests==2.26.0, flask==2.0.2, numpy==1.21.3]
+      - id: pylint
+        name: Pylint (appA)
+        files: ^KBQA/kbqa/appA/
+        additional_dependencies:
+          [flask==2.0.2, requests==2.26.0, SPARQLWrapper==1.8.5]
+      - id: pylint
+        name: Pylint (appB)
+        files: ^KBQA/kbqa/appB/
+        additional_dependencies:
+          [flask==2.0.2, requests==2.26.0, SPARQLWrapper==1.8.5]
+      - id: pylint
+        name: Pylint (website_server)
+        files: ^KBQA/kbqa/website_server/
+        additional_dependencies: [flask==2.0.2, requests==2.26.0]
+      - id: pylint
+        name: Pylint (embedding_server)
+        files: ^KBQA/kbqa/embedding_server/
+        additional_dependencies: [flask==2.0.2, numpy==1.21.3]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
@@ -42,6 +61,23 @@ repos:
     hooks:
       - id: mypy
         name: Mypy - check python static types
+        files: ^(?!.*\/kbqa\/).*
+        additional_dependencies: [types-requests]
+      - id: mypy
+        name: mypy (appA)
+        files: ^KBQA/kbqa/appA/
+        additional_dependencies: [types-requests]
+      - id: mypy
+        name: mypy (appB)
+        files: ^KBQA/kbqa/appB/
+        additional_dependencies: [types-requests]
+      - id: mypy
+        name: mypy (website_server)
+        files: ^KBQA/kbqa/website_server/
+        additional_dependencies: [types-requests]
+      - id: mypy
+        name: mypy (embedding_server)
+        files: ^KBQA/kbqa/embedding_server/
         additional_dependencies: [types-requests]
 
   - repo: https://github.com/PyCQA/pydocstyle
@@ -53,7 +89,8 @@ repos:
 exclude: |
   (?x)^(
     KBQA/appB/transformer_architectures/BERT_CompleX_SPBERT/. |
-    KBQA/appB/transformer_architectures/BERT_WordPiece_SPBERT/.
+    KBQA/appB/transformer_architectures/BERT_WordPiece_SPBERT/. |
+    KBQA/kbqa/webservice/appA/app/nspm/
   )
 
 ci:


### PR DESCRIPTION
While working on the webservice (i.e. in the directory /kbqa), I encountered a problem with the linters from Pylint and MyPy. The problem is that these two linters check for similarities between different files. For example, MyPy will throw an error, if there are multiple files with the same name. However, since the webservice contains different applications/subprojects, which do not interact with each other in the first place, those errors should not be considered (e.g. each application has a file api.py for the API). Therefore, I added hooks for Pylint and MyPy, which check the applications of the webservice individually, s.t. no error is thrown. Furthermore, the /kbqa directory is excluded from the previous checks. This means: Each file/commit, which changes/adds something in the /kbqa directory, is checked as before and each file/commit, which changes/adds something in the /kbqa directory is changed by the same linters as before, but individually on its own.