### PR TITLE
Add resource path environment variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RESOURCE_PATH: /home/kbqa_mngr/resources
+
 jobs:
   deploy:
     runs-on: [self-hosted, kbqa-pg]

--- a/KBQA/kbqa/docker-compose.yml
+++ b/KBQA/kbqa/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: embedding_server
     restart: always
     volumes:
-      - ./resources/embeddings/embedding_query:/embedding_query
+      - ${RESOURCE_PATH}/embeddings/embedding_query:/embedding_query
     expose:
       - 24805
 
@@ -22,7 +22,7 @@ services:
     container_name: approach_a
     restart: always
     volumes:
-      - ./resources/approach_a/data:/data
+      - ${RESOURCE_PATH}/approach_a/data:/data
     expose:
       - 24801
 


### PR DESCRIPTION
The resource directory can now be specified in an environment variable.
For vm deployment it is specified in the actions workflow, so it is not inside the repository folder.
For local deployment you can just define it as '.'