### PR TITLE
Add functions to return whole response from DBspotlight and TagMe

### DIFF
--- a/KBQA/appB/summarizers/one_hop_rank_summarizer/entity_relation_hops.py
+++ b/KBQA/appB/summarizers/one_hop_rank_summarizer/entity_relation_hops.py
@@ -3,7 +3,7 @@ import argparse
 from typing import List
 from typing import Tuple
 
-from KBQA.appB.summarizers.utils import entity_recognition_dbspotlight
+from KBQA.appB.summarizers.utils import entity_recognition_dbspotlight_confidence
 from KBQA.appB.summarizers.utils import entity_recognition_tagme
 from KBQA.appB.summarizers.utils import entity_relation_recognition
 from rdflib import Graph
@@ -52,8 +52,8 @@ def entity_relation_hops(
     """
     _, relations = entity_relation_recognition(question)
     # print("Relations", relations)
-    entities_dbs = entity_recognition_dbspotlight(
-        question, confidence=confidence, include_conf=True
+    entities_dbs = entity_recognition_dbspotlight_confidence(
+        question, confidence=confidence
     )
     entities_tagme = entity_recognition_tagme(question, conf=confidence)
     # print("Entities DBS:", entities_dbs)

--- a/KBQA/tests/appB/test_utils.py
+++ b/KBQA/tests/appB/test_utils.py
@@ -1,0 +1,73 @@
+import unittest
+
+from KBQA.appB.summarizers.utils import query_dbspotlight
+from KBQA.appB.summarizers.utils import entity_recognition_dbspotlight
+from KBQA.appB.summarizers.utils import entity_recognition_dbspotlight_confidence
+from KBQA.appB.summarizers.utils import query_tagme
+from KBQA.appB.summarizers.utils import entity_recognition_tagme
+from rdflib import URIRef
+
+class TestUtils(unittest.TestCase):
+
+    def test_query_dbspotlight(self):
+        """Test the function query_dbspotlight."""
+
+        question = "What is the capital of Germany?"
+
+        result = query_dbspotlight(question)
+
+        self.assertEqual(type(result), dict)
+        self.assertEqual(result["@text"], question)
+        self.assertTrue("Resources" in result)
+
+    def test_entity_recognition_dbspotlight(self):
+        """Test the function entity_recognition_dbspotlight."""
+
+        question_1 = "What is the capital of Germany?"
+        question_2 = "Who is the spouse of Barack Obama?"
+
+        result_1 = entity_recognition_dbspotlight(question_1)
+        result_2 = entity_recognition_dbspotlight(question_2)
+
+        expected_result_1 = [URIRef("http://dbpedia.org/resource/Germany")]
+        expected_result_2 = [URIRef("http://dbpedia.org/resource/Barack_Obama")]
+
+        self.assertListEqual(result_1, expected_result_1)
+        self.assertListEqual(result_2, expected_result_2)
+
+    def test_entity_recognition_dbspotlight_confidence(self):
+        """Test the function entity_recognition_dbspotlight_confidence."""
+
+        question = "Who is the spouse of Barack Obama?"
+
+        result = entity_recognition_dbspotlight_confidence(question)
+
+        expected_entity = URIRef("http://dbpedia.org/resource/Barack_Obama")
+
+        self.assertTrue(len(result) > 0)
+        self.assertEqual(result[0][0], expected_entity)
+        self.assertEqual(type(result[0][1]), float)
+
+    def test_query_tagme(self):
+        """Test the function query_tagme."""
+
+        question = "Who is the spouse of Barack Obama?"
+
+        result = query_tagme(question)
+        
+        self.assertEqual(type(result), dict)
+        self.assertTrue("annotations" in result)
+        self.assertTrue(len(result["annotations"]) > 0)
+
+    def test_entity_recognition_tagme(self):
+        """Test the function entity_recognition_tagme."""
+
+        question = "Who is the spouse of Barack Obama?"
+
+        result = entity_recognition_tagme(question)
+
+        expected_entity = URIRef("http://dbpedia.org/resource/Barack_Obama")
+
+        self.assertTrue(len(result) > 0)
+        self.assertEqual(result[0][0], expected_entity)
+        self.assertEqual(type(result[0][1]), float)


### PR DESCRIPTION
Add a function query_dbspotlight, which returns the response of DBspotlight without any postprocessing.
Add a function query_tagme, which returns the response of TagMe without any postprocessing.