### PR TITLE
Change paths to avoid empty directories (2)

### DIFF
--- a/KBQA/kbqa/webservice/appB/app/arguments/args_bert_wordpiece_spbert.py
+++ b/KBQA/kbqa/webservice/appB/app/arguments/args_bert_wordpiece_spbert.py
@@ -23,7 +23,7 @@ BERT_WORDPIECE_SPBERT = SimpleNamespace(
         "model_architecture": "bert2bert",
         # --output_dir, default="./output/", type=str,
         # help="The output directory where the model predictions and checkpoints will be written."
-        "output_dir": "app/data/",
+        "output_dir": "app/output/",
         # --train_filename, default=None, type=str,
         # help="The train filename. Should contain the .jsonl files for this task."
         "train_filename": None,
@@ -35,7 +35,7 @@ BERT_WORDPIECE_SPBERT = SimpleNamespace(
         "test_filename": None,
         # --predict_filename, default=None, type=str,
         # help="The prediction filename."
-        "predict_filename": "app/data/question",  # "./data/output/qald_9_test",
+        "predict_filename": "app/data/output/question",  # "./data/output/qald_9_test",
         # --source, default="en", type=str,
         # help="The source language (for file extension)"
         "source": "en",

--- a/KBQA/kbqa/webservice/appB/app/arguments/args_postprocessing.py
+++ b/KBQA/kbqa/webservice/appB/app/arguments/args_postprocessing.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 POSTPROCESSING = SimpleNamespace(
     **{
         # path tp predict_file
-        "predict_dir": "app/data",
+        "predict_dir": "app/output/",
         # predict file
         "predict_file": "predict_0.output",
     }

--- a/KBQA/kbqa/webservice/appB/app/arguments/args_preprocessing.py
+++ b/KBQA/kbqa/webservice/appB/app/arguments/args_preprocessing.py
@@ -4,21 +4,21 @@ from types import SimpleNamespace
 SEPERATE_QTQ = SimpleNamespace(
     **{
         # --data, dest="data_dir", required=True
-        "data_dir": "app/data",
+        "data_dir": "app/data/input",
         # --subset, dest="subset", required=True
         "subset": "question",
         # --output, dest="output_dir", required=True
-        "output_dir": "app/data",
+        "output_dir": "app/data/sep",
     }
 )
 
 PREPROCESSING_QTQ = SimpleNamespace(
     **{
         # --data, dest="data_dir", required=True
-        "data_dir": "app/data",
+        "data_dir": "app/data/sep",
         # --subset, dest="subset", required=True
         "subset": "question",
         # --output, dest="output_dir", required=True
-        "output_dir": "app/data",
+        "output_dir": "app/data/output",
     }
 )

--- a/KBQA/kbqa/webservice/appB/app/main.py
+++ b/KBQA/kbqa/webservice/appB/app/main.py
@@ -1,9 +1,11 @@
 """Main module for the application logic of approach B."""
 import json
+import os
 from typing import Any
 from typing import Dict
 from typing import List
 
+from app.arguments.args_preprocessing import SEPERATE_QTQ
 from app.arguments.args_summarizer import ONE_HOP_RANK_SUMMARIZER
 from app.bert_wordpiece_spbert.run import run
 from app.postprocessing.postprocessing import postprocessing
@@ -165,7 +167,13 @@ def save_summarized_result(question: str, sparql: str, triples: str) -> None:
     triples : str
         List of triples in the format <subject> <predicate> <object>.
     """
-    path = "app/data/input/question.json"
+    data_dir = SEPERATE_QTQ.data_dir
+
+    # create input directory to store QTQ dataset for preprocessing
+    if os.path.exists(data_dir) is False:
+        os.makedirs(data_dir)
+
+    filename = f"{SEPERATE_QTQ.subset}.json"
 
     dataset: Dict[str, List[Dict]] = {"questions": list()}
 
@@ -175,5 +183,5 @@ def save_summarized_result(question: str, sparql: str, triples: str) -> None:
     qtq["triples"] = triples
     dataset["questions"].append(qtq)
 
-    with open(path, "w", encoding="utf-8") as file:
+    with open(f"{data_dir}/{filename}", "w", encoding="utf-8") as file:
         json.dump(dataset, file, indent=4, separators=(",", ": "))

--- a/KBQA/kbqa/webservice/appB/app/preprocessing/preprocessing_qtq.py
+++ b/KBQA/kbqa/webservice/appB/app/preprocessing/preprocessing_qtq.py
@@ -1,4 +1,5 @@
 """Preprocess a seperated QTQ dataset to prepare it for the use of SPBert."""
+import os
 import re
 from typing import List
 
@@ -108,6 +109,10 @@ def preprocessing_qtq() -> None:
 
     data_dir = data_dir.rstrip("/")
     output_dir = output_dir.rstrip("/")
+
+    # create output directory to store output files for SPBERT
+    if os.path.exists(output_dir) is False:
+        os.makedirs(output_dir)
 
     with open(f"{output_dir}/{subset}.en", "w", encoding="utf-8") as out:
         with open(f"{data_dir}/{subset}.en", encoding="utf-8") as file:

--- a/KBQA/kbqa/webservice/appB/app/preprocessing/seperate_qtq.py
+++ b/KBQA/kbqa/webservice/appB/app/preprocessing/seperate_qtq.py
@@ -1,5 +1,6 @@
 """Module to seperate a QTQ dataset into an en, sparql and triple file."""
 import json
+import os
 from typing import List
 
 from app.arguments.args_preprocessing import SEPERATE_QTQ
@@ -30,12 +31,16 @@ def seperate_qtq() -> None:
     output_dir = args.output_dir
 
     data_dir = data_dir.rstrip("/")
-    output_dir = output_dir.rstrip("/")
+    sep_dir = output_dir.rstrip("/")
 
-    with open(f"{output_dir}/{subset}.en", "w", encoding="utf-8") as en_file, open(
-        f"{output_dir}/{subset}.sparql", "w", encoding="utf-8"
+    # create sep directory to store seperated files
+    if os.path.exists(sep_dir) is False:
+        os.makedirs(sep_dir)
+
+    with open(f"{sep_dir}/{subset}.en", "w", encoding="utf-8") as en_file, open(
+        f"{sep_dir}/{subset}.sparql", "w", encoding="utf-8"
     ) as sparql_file, open(
-        f"{output_dir}/{subset}.triple", "w", encoding="utf-8"
+        f"{sep_dir}/{subset}.triple", "w", encoding="utf-8"
     ) as triple_file, open(
         f"{data_dir}/{subset}.json", "r", encoding="utf-8"
     ) as data_file:


### PR DESCRIPTION
Revert changes from previous PR, which changed the paths in order to avoid empty directories. Instead, the directories are created, when the app is loaded/executed